### PR TITLE
Use http to validate Node distro support

### DIFF
--- a/tasks/ie_proxy.yml
+++ b/tasks/ie_proxy.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if the Ubuntu distro is supported
-  get_url: url="https://deb.nodesource.com/node/dists/{{ ansible_distribution_release }}/Release" dest=/dev/null
+  get_url: url="http://deb.nodesource.com/node/dists/{{ ansible_distribution_release }}/Release" dest=/dev/null
   register: distro_supported
 
 - name: Ensure apt-transport-https is installed.


### PR DESCRIPTION
This change to work around failure to validate the SSL certificate for
deb.nodesource.com.

Fixes [issue 459 in docker-galaxy-stable](https://github.com/bgruening/docker-galaxy-stable/issues/459) which was resulting in this error:

```
TASK [galaxyprojectdotorg.galaxyextras : Check if the Ubuntu distro is supported] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to validate the SSL certificate for deb.nodesource.com:443. Make sure your managed systems have a valid CA certificate installed. If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine  (the python executable used (/usr/bin/python) is version: 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]) or you can install the `urllib3`, `pyOpenSSL`, `ndg-httpsclient`, and `pyasn1` python modules to perform SNI verification in python >= 2.6. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible. The exception msg was: [Errno 1] _ssl.c:510: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure."}
        to retry, use: --limit @/ansible/provision.retry
```